### PR TITLE
Add CI for plone.base.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,25 @@
+name: tests
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+  workflow_dispatch:
+jobs:
+  build:
+    strategy:
+      matrix:
+        # python-version: ["3.7", "3.8", "3.9", "3.10"]
+        # Start with just one version.
+        python-version: ["3.9"]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+    - name: Install dependencies
+      run: ./prep.sh
+    - name: Test
+      run: zope-testrunner --test-path=src

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.egg-info
 __pycache__
+constraints-mxdev.txt
+requirements-mxdev.txt

--- a/prep.sh
+++ b/prep.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# This script works best when run in GitHub Actions or using tox:
+# then it will take the correct Python version.
+BASEDIR=$(dirname $(realpath $0))
+python -m pip install --upgrade pip
+pip install mxdev libvcs==0.11.1
+mxdev -c sources.ini
+pip install -r${BASEDIR}/requirements-mxdev.txt
+python -V
+pip list

--- a/prep.sh
+++ b/prep.sh
@@ -3,7 +3,7 @@
 # then it will take the correct Python version.
 BASEDIR=$(dirname $(realpath $0))
 python -m pip install --upgrade pip
-pip install mxdev libvcs==0.11.1
+pip install wheel mxdev libvcs==0.11.1
 mxdev -c sources.ini
 pip install -r${BASEDIR}/requirements-mxdev.txt
 python -V

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+-e .[test]
+zope.testrunner
+--pre
+-c https://dist.plone.org/release/6.0-dev/constraints.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,6 +65,11 @@ ignore =
   .coveragerc
   .editorconfig
   .gitattributes
+  prep.sh
+  pyproject.toml
+  requirements.txt
+  sources.ini
+  tox.ini
 
 [flake8]
 exclude = docs,*.egg.

--- a/sources.ini
+++ b/sources.ini
@@ -1,0 +1,10 @@
+[settings]
+# This is a mxdev configuration file
+#
+# available options are documented at
+# https://pypi.org/project/mxdev/
+
+requirements-in = requirements.txt
+# requirements-out = requirements-60-mxdev.txt
+# constraints-out = constraints-60-mxdev.txt
+ignores = plone.base

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist =
+    py37,
+    py38,
+    py39,
+    py310,
+skip_missing_interpreters = False
+
+[testenv]
+usedevelop = False
+skip_install = true
+commands_pre = {toxinidir}/prep.sh
+commands = zope-testrunner --test-path={toxinidir}/src {posargs:-vc}


### PR DESCRIPTION
We should catch it when we miss a dependency, or notice when a dependency pulls in too many others.
We currently miss the `plone.schema` dependency, needed for the `Email` field. Reported in issue #9, which needs a solution first.
