### PR TITLE
Fix permissions during traversal executed from `get_top_site_from_url()`.

### DIFF
--- a/news/19.bugfix
+++ b/news/19.bugfix
@@ -1,0 +1,1 @@
+* Fix issue with traversal introduced by [Rudd-O] in `get_top_site_from_url()` [Rudd-O]

--- a/src/plone/base/utils.py
+++ b/src/plone/base/utils.py
@@ -246,7 +246,7 @@ def get_top_site_from_url(context, request):
     """
     Find the first ISite object that appears in the pre-virtual-hosting URL
     path, falling back to the object pointed by the virtual hosting root.
-    
+
     Use this method if you need a "root object" reference to generate URLs
     that will be used by, and will work correctly from the standpoint of,
     *browser* code (JavaScript / XML HTTP requests) after virtual hosting has
@@ -312,7 +312,11 @@ def get_top_site_from_url(context, request):
         for idx in range(len(url_path)):
             _path = "/".join(url_path[: idx + 1]) or "/"
             site_path = "/".join(request.physicalPathFromURL(_path)) or "/"
-            _site = context.restrictedTraverse(site_path)
+            # The following line is fine.  We do a restrictedTraverse
+            # below to resolve the actual object, so the user (technically,
+            # the browser) cannot ever get a reference to an object it does
+            # not have permission to.
+            _site = context.unrestrictedTraverse(site_path)
             if ISite.providedBy(_site):
                 subsites.append(idx)
             else:


### PR DESCRIPTION
My previous fix broke several tests.  This appears to be the result of trying to traverse iteratively through the structure of a site (which my code does and the previous code does not do in the same way), and encountering `Unauthorized` exceptions during traversal (which is a legitimate thing to get, as /a/b/c may be accessible to user XXX, but /a/b may not necessarily be).

The fix is to use unrestricted traversal (bypassing security), and then to return the selected object by using *restricted* traversal in that case.

I am confident this should not result in a security issue — however I ask the true expert Plonistas to verify this confidence is warranted.  Thanks.

And sorry for the breakage.  We need CI tests in `plone.base`.