### PR TITLE
Fix uses of unrestrictedTraverse in get_top_site_from_url()

### DIFF
--- a/news/20.bugfix
+++ b/news/20.bugfix
@@ -1,0 +1,1 @@
+* Fix `get_top_site_from_url()` when the path contains nonexistent objects (e.g. when creating a new Dexterity type or adding a new content instance). [Rudd-O]

--- a/src/plone/base/tests/test_utils.py
+++ b/src/plone/base/tests/test_utils.py
@@ -82,6 +82,9 @@ class DefaultUtilsTests(unittest.TestCase):
             def restrictedTraverse(self, path):
                 return MockContext(self.vh_root + path)
 
+            def unrestrictedTraverse(self, path):
+                return self.restrictedTraverse(path)
+
         class MockRequest:
             vh_url = "http://nohost"
             vh_root = ""

--- a/src/plone/base/utils.py
+++ b/src/plone/base/utils.py
@@ -9,6 +9,7 @@ from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import ITypesTool
 from Products.CMFCore.utils import getToolByName
 from urllib.parse import urlparse
+from zExceptions import NotFound
 from ZODB.POSException import ConflictError
 from zope.component import getMultiAdapter
 from zope.component import getUtility
@@ -316,7 +317,12 @@ def get_top_site_from_url(context, request):
             # below to resolve the actual object, so the user (technically,
             # the browser) cannot ever get a reference to an object it does
             # not have permission to.
-            _site = context.unrestrictedTraverse(site_path)
+            try:
+                _site = context.unrestrictedTraverse(site_path)
+            except NotFound:
+                # Oh.  This path is not findable.  So we will not consider
+                # it below as a thing we can return to stand in for ISite.
+                continue
             if ISite.providedBy(_site):
                 subsites.append(idx)
             else:


### PR DESCRIPTION
In some cases (when an object does not yet exist, for example) this method being called must skip these nonexistent objects from the recursive evaluation being done to discover the appropriate site to return.