### PR TITLE
disable TinyMCE advlist plugin, it produces unclean inline styles

### DIFF
--- a/news/21.feature
+++ b/news/21.feature
@@ -1,0 +1,1 @@
+disable TinyMCE advlist plugin, it produces unclean inline styles [MrTango]

--- a/src/plone/base/interfaces/controlpanel.py
+++ b/src/plone/base/interfaces/controlpanel.py
@@ -557,7 +557,6 @@ class ITinyMCEPluginSchema(Interface):
             )
         ),
         default=[
-            "advlist",
             "fullscreen",
             "hr",
             "lists",


### PR DESCRIPTION
This plugin should not be used at all, but at least not by default.
It does everything with inline styles.
The recommended way to do table styling is with the formats, similar to how we did it since Plone 4.