### PR TITLE
Add available tinymce plugin `autolink` to the selectable plugins

### DIFF
--- a/news/25.bugfix
+++ b/news/25.bugfix
@@ -1,0 +1,2 @@
+Add missing TinyMCE plugin `autolink` to selectable plugins.
+[petschki]

--- a/src/plone/base/interfaces/controlpanel.py
+++ b/src/plone/base/interfaces/controlpanel.py
@@ -522,6 +522,7 @@ class ITinyMCEPluginSchema(Interface):
                 [
                     SimpleTerm("advlist", "advlist", "advlist"),
                     SimpleTerm("anchor", "anchor", "anchor"),
+                    SimpleTerm("autolink", "autolink", "autolink"),
                     SimpleTerm("autosave", "autosave", "autosave"),
                     SimpleTerm("charmap", "charmap", "charmap"),
                     SimpleTerm("code", "code", "code"),


### PR DESCRIPTION
@jensens question: this needs an upgradestep to load the new vocabulary into the registry. Where do I have to put this?