### PR TITLE
Add `required=False` to missing boolean field from syndication config

### DIFF
--- a/news/14.bugfix
+++ b/news/14.bugfix
@@ -1,0 +1,2 @@
+Add `required=False` to missing boolean field from syndication config 
+[frapell]

--- a/src/plone/base/interfaces/syndication.py
+++ b/src/plone/base/interfaces/syndication.py
@@ -230,7 +230,11 @@ class ISiteSyndicationSettings(Interface):
 
 class IFeedSettings(Interface):
 
-    enabled = schema.Bool(title=_("Enabled"), default=False)
+    enabled = schema.Bool(
+        title=_("Enabled"),
+        default=False,
+        required=False
+    )
 
     feed_types = schema.Tuple(
         title=_("Feed Types"),


### PR DESCRIPTION
This Bool field was missed when ticket gh-14 got merged