### PR TITLE
Improve check on created content ID

### DIFF
--- a/news/35.bugfix
+++ b/news/35.bugfix
@@ -1,0 +1,1 @@
+Check for container field / attribute when trying to create content with same id [laulaz]

--- a/src/plone/base/utils.py
+++ b/src/plone/base/utils.py
@@ -506,6 +506,10 @@ def _check_for_collision(contained_by, cid, **kwargs):
                 mapping={"name": cid},
             )
 
+    # containers may have a field / attribute of the same name
+    if base_hasattr(contained_by, cid):
+        return _("${name} is reserved.", mapping={"name": cid})
+
     # containers may implement this hook to further restrict ids
     if getattr(aq_base(contained_by), "checkValidId", _marker) is not _marker:
         try:


### PR DESCRIPTION
We need to check for container field / attribute when trying to create content with same id

This refs #35