### PR TITLE
Add help tinymce plugin

### DIFF
--- a/news/41.feature
+++ b/news/41.feature
@@ -1,0 +1,1 @@
+Make the TinyMCE help plugin available as an option [ewohnlich]

--- a/src/plone/base/interfaces/controlpanel.py
+++ b/src/plone/base/interfaces/controlpanel.py
@@ -543,6 +543,7 @@ class ITinyMCEPluginSchema(Interface):
                     SimpleTerm("emoticons", "emoticons", "emoticons"),
                     SimpleTerm("fullpage", "fullpage", "fullpage"),
                     SimpleTerm("fullscreen", "fullscreen", "fullscreen"),
+                    SimpleTerm("help", "help", "help"),
                     SimpleTerm("hr", "hr", "hr"),
                     SimpleTerm("insertdatetime", "insertdatetime", "insertdatetime"),
                     SimpleTerm("layer", "layer", "layer"),


### PR DESCRIPTION
TinyMCE comes with a `help` plugin by default. For some reason it is not included in the schema of baseline plugins though. Can we add it?