### PR TITLE
Remove 'Discussion Item' from SearchSchema (helps also to turn pa.discussion into a core addon)

### DIFF
--- a/news/65.bugfix
+++ b/news/65.bugfix
@@ -1,0 +1,4 @@
+Remove ISearchSchemas types_not_searched "Discussion Item" value from plone.app.discussion and other impossible values too.
+Default is empty now, since there will never the construction allowed of these three.
+See https://github.com/zopefoundation/Products.CMFCore/blob/8d765b8ce7ec4e053e58f5c8dc45d08db01ce3e0/src/Products/CMFCore/TypesTool.py#L768
+[@jensens]

--- a/news/65.bugfix
+++ b/news/65.bugfix
@@ -1,4 +1,4 @@
-Remove ISearchSchemas types_not_searched "Discussion Item" value from plone.app.discussion and other impossible values too.
-Default is empty now, since there will never the construction allowed of these three.
+Remove ISearchSchemas types_not_searched "Discussion Item" value to make plone.app.discussion a core addon.
+It is actually not needed anyway, also not part of the underlying vocabulary and would be lost on first save in control-panel.
 See https://github.com/zopefoundation/Products.CMFCore/blob/8d765b8ce7ec4e053e58f5c8dc45d08db01ce3e0/src/Products/CMFCore/TypesTool.py#L768
 [@jensens]

--- a/src/plone/base/interfaces/controlpanel.py
+++ b/src/plone/base/interfaces/controlpanel.py
@@ -1015,11 +1015,7 @@ class ISearchSchema(Interface):
             "off here or by the relevant installer."
         ),
         required=False,
-        default=(
-            "Discussion Item",
-            "Plone Site",
-            "TempFolder",
-        ),
+        default=(),
         missing_value=(),
         value_type=schema.Choice(source="plone.app.vocabularies.PortalTypes"),
     )

--- a/src/plone/base/interfaces/controlpanel.py
+++ b/src/plone/base/interfaces/controlpanel.py
@@ -1015,7 +1015,13 @@ class ISearchSchema(Interface):
             "off here or by the relevant installer."
         ),
         required=False,
-        default=(),
+        # XXX: Actually, the Plone Site and TempFolder are not part of the vocabulary
+        # and would be removed from the list of types not searched on first save in ControlPanel!
+        # Both are used in many tests and kept for now.
+        default=(
+            "Plone Site",
+            "TempFolder",
+        ),
         missing_value=(),
         value_type=schema.Choice(source="plone.app.vocabularies.PortalTypes"),
     )


### PR DESCRIPTION
With plone.app.discussion `Discussion Item` is not available by default.

But: "TempFolder" and "Plone Site" are at no time in the constraint vocabulary used. So I removed them as well.

see https://github.com/plone/plone.app.discussion/pull/211  
This one can be merged alone and is valid for 6.0 too.