### PR TITLE
Fixed tests when using Zope 5.11.

### DIFF
--- a/news/956.tests
+++ b/news/956.tests
@@ -1,0 +1,3 @@
+Fixed tests when using Zope 5.11.
+In one test we got a `mappingproxy` instead of a dictionary.
+[maurits]

--- a/src/plone/base/tests/messages.rst
+++ b/src/plone/base/tests/messages.rst
@@ -36,7 +36,7 @@ And at last there is the possibility of variable substitution:
   >>> msg.default
   'Hello ${name}'
 
-  >>> msg.mapping
+  >>> dict(msg.mapping)
   {'name': 'Plone'}
 
 Messages with translation service set up


### PR DESCRIPTION
In one test we got a `mappingproxy` instead of a dictionary:

```
File "...plone.base-2.0.1-py3.10.egg/plone/base/tests/messages.rst", line 39, in messages.rst
Failed example:
    msg.mapping
Expected:
    {'name': 'Plone'}
Got:
    mappingproxy({'name': 'Plone'})
```