### PR TITLE
Fix outdated TinyMCE toolbar and menu button names

### DIFF
--- a/news/86.bugfix
+++ b/news/86.bugfix
@@ -1,0 +1,1 @@
+Fix outdated TinyMCE toolbar button and menu settings to match TinyMCE version 6. @petschki

--- a/src/plone/base/interfaces/controlpanel.py
+++ b/src/plone/base/interfaces/controlpanel.py
@@ -623,7 +623,7 @@ class ITinyMCEPluginSchema(Interface):
                 "format": {
                     "title": "Format",
                     "items": "bold italic underline strikethrough "
-                    "superscript subscript | formats | removeformat",
+                    "superscript subscript | styles | removeformat",
                 },
                 "table": {
                     "title": "Table",
@@ -658,7 +658,7 @@ class ITinyMCEPluginSchema(Interface):
             default=("Enter how you would like the toolbar items to list."),
         ),
         required=True,
-        default="ltr rtl | undo redo | styleselect | bold italic | "
+        default="ltr rtl | undo redo | styles | bold italic | "
         "alignleft aligncenter alignright alignjustify | "
         "bullist numlist outdent indent | "
         "inserttable | unlink plonelink ploneimage",


### PR DESCRIPTION
this superseeds #91 

see https://github.com/plone/plone.app.upgrade/pull/350