### PR TITLE
Allow to create content with `index_html` id on the site root.

### DIFF
--- a/news/4278.bugfix.rst
+++ b/news/4278.bugfix.rst
@@ -1,0 +1,8 @@
+Allow to create content with `index_html` id on the site root.
+
+The portal root has a `index_html` method which prevented content with the id
+`index_html` to be created and used as a default page.
+
+Fixes: https://github.com/plone/Products.CMFPlone/issues/4278
+
+@thet

--- a/src/plone/base/tests/test_utils.py
+++ b/src/plone/base/tests/test_utils.py
@@ -217,3 +217,58 @@ class DefaultUtilsTests(unittest.TestCase):
         self.assertFalse(is_truthy("NO"))
         self.assertFalse(is_truthy("no"))
         self.assertFalse(is_truthy("foo"))
+
+    def test_check_for_collision(self):
+        from plone.base.utils import _check_for_collision
+
+        class Container(dict):
+            def __getattribute__(self, name):
+                if name in self:
+                    return self[name]
+                return object.__getattribute__(self, name)
+
+            def portal_type(self):
+                """Necessary to fulfill protocol."""
+
+            def index_html(self):
+                """Common attribute - content with id index_html should be
+                addable."""
+
+            def some_attr(self):
+                """Random attribute - content with id some_attr should not be
+                addable."""
+
+        container = Container()
+        container["test"] = Container()
+
+        # "test" is already taken
+        self.assertIn(
+            "There is already an item named",
+            _check_for_collision(container, "test"),
+        )
+
+        # "tiptop" is not yet taken
+        self.assertEqual(
+            _check_for_collision(container, "tiptop"),
+            None,
+        )
+
+        # "index_html" is not yet taken
+        self.assertEqual(
+            _check_for_collision(container, "index_html"),
+            None,
+        )
+
+        container["index_html"] = Container()
+
+        # `False` as "index_html" is now taken
+        self.assertIn(
+            "There is already an item named",
+            _check_for_collision(container, "index_html"),
+        )
+
+        # Content ids are not addable, if the id is an container attribute.
+        self.assertIn(
+            "is reserved",
+            _check_for_collision(container, "some_attr"),
+        )

--- a/src/plone/base/utils.py
+++ b/src/plone/base/utils.py
@@ -506,6 +506,10 @@ def _check_for_collision(contained_by, cid, **kwargs):
                 mapping={"name": cid},
             )
 
+    if cid == "index_html":
+        # always allow index_html
+        return
+
     # containers may have a field / attribute of the same name
     if base_hasattr(contained_by, cid):
         return _("${name} is reserved.", mapping={"name": cid})
@@ -533,9 +537,6 @@ def _check_for_collision(contained_by, cid, **kwargs):
     # However, we do want to allow overriding of *content* in the object's
     # parent path, including the portal root.
 
-    if cid == "index_html":
-        # always allow index_html
-        return
     portal = getSite()
     if portal and cid in portal.contentIds():
         # Fine to use the same id as a *content* item from the root.


### PR DESCRIPTION
**First this needs to be merged in order to get the z3c.dependencychecker check green:
https://github.com/plone/plone.base/pull/108**

The portal root has a `index_html` method which prevented content with the id `index_html` to be created and used as a default page.

Fixes: https://github.com/plone/Products.CMFPlone/issues/4278

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes https://github.com/plone/Products.CMFPlone/issues/4278


