### PR TITLE
Update id collision checks with missing checks from CMFPlone.

### DIFF
--- a/news/+check-id-update.bugfix.rst
+++ b/news/+check-id-update.bugfix.rst
@@ -1,0 +1,7 @@
+Update id collision checks with missing checks from CMFPlone.
+
+Some of the checks in `utils._check_for_collision` or erroneous. These checks
+were updated with the original checks from CMFPlone. The tests depend on a
+fully set-up site and remain in CMFPlone.
+
+[thet]

--- a/src/plone/base/tests/test_utils.py
+++ b/src/plone/base/tests/test_utils.py
@@ -219,6 +219,11 @@ class DefaultUtilsTests(unittest.TestCase):
         self.assertFalse(is_truthy("foo"))
 
     def test_check_for_collision(self):
+        """Test the collision for ids in containers.
+
+        There are more complete tests which require a fully set-up Plone site
+        in: `Products.CMFPlone.tests.testCheckId`
+        """
         from plone.base.utils import _check_for_collision
 
         class Container(dict):

--- a/src/plone/base/utils.py
+++ b/src/plone/base/utils.py
@@ -1,5 +1,6 @@
 from . import PloneMessageFactory as _
 from .interfaces import ISearchSchema
+from AccessControl import getSecurityManager
 from AccessControl import Unauthorized
 from Acquisition import aq_base
 from Acquisition import aq_get
@@ -7,6 +8,7 @@ from Acquisition import aq_parent
 from DateTime import DateTime
 from plone.registry.interfaces import IRegistry
 from Products.CMFCore.interfaces import ITypesTool
+from Products.CMFCore.permissions import AddPortalContent
 from Products.CMFCore.utils import getToolByName
 from urllib.parse import urlparse
 from zExceptions import NotFound
@@ -514,6 +516,16 @@ def _check_for_collision(contained_by, cid, **kwargs):
     if base_hasattr(contained_by, cid):
         return _("${name} is reserved.", mapping={"name": cid})
 
+    if base_hasattr(contained_by, "checkIdAvailable"):
+        # ‌`checkIdAvailable` is implemented by
+        # ‌`Products.CMFCore.PortalFolder.PortalFolderBase`
+        # Historically this used to be called from the check_id skin script,
+        # which would check the permission automatically,
+        # and the code would catch the Unauthorized exception.
+        if getSecurityManager().checkPermission(AddPortalContent, contained_by):
+            if not contained_by.checkIdAvailable(cid):
+                return _("${name} is reserved.", mapping={"name": cid})
+
     # containers may implement this hook to further restrict ids
     if getattr(aq_base(contained_by), "checkValidId", _marker) is not _marker:
         try:
@@ -524,11 +536,12 @@ def _check_for_collision(contained_by, cid, **kwargs):
             return _("${name} is reserved.", mapping={"name": cid})
 
     # make sure we don't collide with any parent method aliases
-    types_tool = getToolByName(contained_by, "types_tool", None)
-    if types_tool is not None:
-        parentFti = types_tool.getTypeInfo(contained_by)
+    plone_utils = getToolByName(contained_by, "plone_utils", None)
+    portal_types = getToolByName(contained_by, "portal_types", None)
+    if plone_utils is not None and portal_types is not None:
+        parentFti = portal_types.getTypeInfo(contained_by)
         if parentFti is not None:
-            aliases = parentFti.getMethodAliases()
+            aliases = plone_utils.getMethodAliases(parentFti)
             if aliases is not None and cid in aliases.keys():
                 return _("${name} is reserved.", mapping={"name": cid})
 


### PR DESCRIPTION
Some of the checks in `utils._check_for_collision` or erronous. These checks were updated with the original checks from CMFPlone. The tests depend on a fully set-up site and remain in CMFPlone.

While working on https://github.com/plone/Products.CMFPlone/pull/4282 the failing tests revealed an incomplete `_check_for_collision` method. Before PR 4282 the cmfplone tests were importing the `_check_for_collision` method from CMFPlone itself which was nowhere used anymore except in the tests, so the failure in plone.base.utils._check_for_collision did not surface.
This PR and the one in https://github.com/plone/Products.CMFPlone/pull/4282 fixes that.

- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [x] If needed, I added new tests for my changes.
- [x] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

If your pull request closes an open issue, include the exact text below, immediately followed by the issue number. When your pull request gets merged, then that issue will close automatically.

Closes #

