### PR TITLE
Add s to valid_tags default

### DIFF
--- a/news/3069.bugfix
+++ b/news/3069.bugfix
@@ -1,0 +1,2 @@
+Add ``s`` to default ``valid_tags`` so TinyMCE strikethrough is not stripped on save.
+@jensens

--- a/src/plone/base/interfaces/controlpanel.py
+++ b/src/plone/base/interfaces/controlpanel.py
@@ -294,6 +294,7 @@ class IFilterSchema(Interface):
             "rp",
             "rt",
             "ruby",
+            "s",
             "samp",
             "section",
             "small",


### PR DESCRIPTION
Add `s` to default `valid_tags` so TinyMCE 8 strikethrough (`<s>`) is not stripped by HTML filtering.

Fixes plone/Products.CMFPlone#3069

Companion PR: upgrade step in plone.app.upgrade (forthcoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)