### PR TITLE
Add missing TinyMCE `codesample` plugin.

### DIFF
--- a/news/+tinyce_plugin.bugfix.md
+++ b/news/+tinyce_plugin.bugfix.md
@@ -1,0 +1,1 @@
+Add missing `codesample` TinyMCE plugin.  @petschki

--- a/src/plone/base/interfaces/controlpanel.py
+++ b/src/plone/base/interfaces/controlpanel.py
@@ -541,10 +541,13 @@ class ITinyMCEPluginSchema(Interface):
                     SimpleTerm("advlist", "advlist", "advlist"),
                     SimpleTerm("anchor", "anchor", "anchor"),
                     SimpleTerm("autolink", "autolink", "autolink"),
+                    # NOTE: "autoresize" is enabled with the autoresize setting below
                     # XXX disable autosave since it is not implemented
                     # SimpleTerm("autosave", "autosave", "autosave"),
                     SimpleTerm("charmap", "charmap", "charmap"),
                     SimpleTerm("code", "code", "code"),
+                    # NOTE: codesample plugin needs prismjs manually installed. see https://www.tiny.cloud/docs/tinymce/latest/codesample/
+                    SimpleTerm("codesample", "codesample", "codesample"),
                     SimpleTerm("directionality", "directionality", "directionality"),
                     SimpleTerm("emoticons", "emoticons", "emoticons"),
                     SimpleTerm("fullscreen", "fullscreen", "fullscreen"),


### PR DESCRIPTION
- [x] I signed and returned the [Plone Contributor Agreement](https://plone.org/foundation/contributors-agreement), and received and accepted an invitation to join a team in the Plone GitHub organization.
- [x] I verified there aren't any other open pull requests for the same change.
- [x] I followed the guidelines in [Contributing to Plone](https://6.docs.plone.org/contributing/index.html).
- [x] I successfully ran code quality checks on my changes locally.
- [x] I successfully ran tests on my changes locally.
- [ ] If needed, I added new tests for my changes.
- [ ] If needed, I added [documentation](https://6.docs.plone.org/contributing/documentation/index.html) for my changes.
- [x] I included a [change log entry](https://6.docs.plone.org/contributing/index.html#contributing-change-log-label) in my commits.

-----

See https://community.plone.org/t/how-can-i-use-an-unregistered-opensource-plugin-for-tinymce/22951 ...

Test and merge together with https://github.com/plone/plone.app.upgrade/pull/370