### PR TITLE
Remove deprecation warning for `Batch.__len__` again.

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -20,6 +20,8 @@ jobs:
         - ["ubuntu", "ubuntu-latest"]
         config:
         # [Python version, visual name, tox env]
+        - ["3.14", "6.3 on py3.14", "py314-plone63"]
+        - ["3.10", "6.3 on py3.10", "py310-plone63"]
         - ["3.14", "6.2 on py3.14", "py314-plone62"]
         - ["3.10", "6.2 on py3.10", "py310-plone62"]
 

--- a/.meta.toml
+++ b/.meta.toml
@@ -3,10 +3,10 @@
 # See the inline comments on how to expand/tweak this configuration file
 [meta]
 template = "default"
-commit-id = "2.8.0"
+commit-id = "2.9.1.dev0"
 
 [tox]
-test_matrix = {"6.2" = ["*"]}
+test_matrix = {"6.3" = ["*"], "6.2" = ["*"]}
 
 [flake8]
 extra_lines = """

--- a/news/+meta.internal
+++ b/news/+meta.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/news/3176.bugfix.rst
+++ b/news/3176.bugfix.rst
@@ -1,0 +1,3 @@
+Remove deprecation warning for `Batch.__len__` again.
+Calling this method is simply unavoidable.
+[maurits]

--- a/src/plone/base/batch.py
+++ b/src/plone/base/batch.py
@@ -1,6 +1,5 @@
 from plone.batching.batch import QuantumBatch
 from plone.batching.utils import calculate_pagerange
-from zope.deprecation import deprecate
 from ZTUtils import make_query
 
 
@@ -24,7 +23,6 @@ class Batch(QuantumBatch):
         )
         self.b_start_str = b_start_str
 
-    @deprecate("Use length attribute instead of __len__")
     def __len__(self):
         # Note: Using len() was deprecated for several years.
         # It was recommended to explicitly either use the `length` attribute
@@ -36,6 +34,14 @@ class Batch(QuantumBatch):
         # on batches, making the deprecation warning unavoidable
         # and thus unnecessary.
         # See https://github.com/plone/Products.CMFPlone/issues/3176
+        # That same Products.PageTemplate code also calls `list` on batches,
+        # and apparently this automatically invokes `__len__`, making it even
+        # more unavoidable.
+        # The deprecation was inadvertently added again during the move to
+        # plone.base in Plone 6.0.  Compare:
+        # https://github.com/plone/Products.CMFPlone/commit/2cc25159443759573360af51216bcb9253cc87c1#diff-fa1e7e5e81879e8c4f4485cf8d8204eba6f2677cb9f4e29de4776b0c1f0d4d93L21
+        # with
+        # https://github.com/plone/plone.base/commit/6e26a377f7153ea6631a6ad58b7a9008fd3d6e53#diff-316da888fe8d39c68d5e0aee055b3bbfa95d522b4b09fe56b7edb1289bd72f9fR28
         return self.length
 
     def __bool__(self):

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,11 @@ min_version = 4.4.0
 envlist =
     lint
     test
+    py314-plone63
+    py313-plone63
+    py312-plone63
+    py311-plone63
+    py310-plone63
     py314-plone62
     py313-plone62
     py312-plone62
@@ -112,6 +117,7 @@ set_env =
 ##
 deps =
     {[test_runner]deps}
+    plone63: -c https://dist.plone.org/release/6.3-dev/constraints.txt
     plone62: -c https://dist.plone.org/release/6.2-dev/constraints.txt
 
 ##
@@ -153,7 +159,7 @@ constrain_package_deps = {[base]constrain_package_deps}
 set_env = {[base]set_env}
 deps =
     {[test_runner]deps}
-    -c https://dist.plone.org/release/6.2-dev/constraints.txt
+    -c https://dist.plone.org/release/6.3-dev/constraints.txt
 
 commands = {[test_runner]test}
 extras = {[base]extras}
@@ -179,7 +185,7 @@ set_env = {[base]set_env}
 deps =
     {[test_runner]deps}
     coverage
-    -c https://dist.plone.org/release/6.2-dev/constraints.txt
+    -c https://dist.plone.org/release/6.3-dev/constraints.txt
 
 commands = {[test_runner]coverage}
 extras = {[base]extras}
@@ -192,7 +198,7 @@ deps =
     twine
     build
     towncrier
-    -c https://dist.plone.org/release/6.2-dev/constraints.txt
+    -c https://dist.plone.org/release/6.3-dev/constraints.txt
 commands =
     # fake version to not have to install the package
     # we build the change log as news entries might break
@@ -222,7 +228,7 @@ allowlist_externals =
 deps =
     pipdeptree
     pipforester
-    -c https://dist.plone.org/release/6.2-dev/constraints.txt
+    -c https://dist.plone.org/release/6.3-dev/constraints.txt
 commands =
     # Generate the full dependency tree
     sh -c 'pipdeptree -j > forest.json'


### PR DESCRIPTION
Calling this method is simly unavoidable.
When a page template does a `tal:repeat` over a batch, `Products.PageTemplates` calls `list(batch)` and `len(batch)`, both of which invoke calling `__len__`. You can try this out with `bin/zopepy`:

```
$ bin/zopepy
>>> from plone.base.batch import Batch
>>> len(Batch(range(10), 3))
<console>:1: DeprecationWarning: Use length attribute instead of __len__
3
>>> list(Batch(range(10), 3))
<console>:1: DeprecationWarning: Use length attribute instead of __len__
[0, 1, 2]
```

The deprecation warning was removed in Plone 5.2.3, see https://github.com/plone/Products.CMFPlone/issues/3176 But during the move of the `Batch` class to `plone.base` in Plone 6.0 it was added again. Compare:

* https://github.com/plone/Products.CMFPlone/commit/2cc25159443759573360af51216bcb9253cc87c1#diff-fa1e7e5e81879e8c4f4485cf8d8204eba6f2677cb9f4e29de4776b0c1f0d4d93L21
* https://github.com/plone/plone.base/commit/6e26a377f7153ea6631a6ad58b7a9008fd3d6e53#diff-316da888fe8d39c68d5e0aee055b3bbfa95d522b4b09fe56b7edb1289bd72f9fR28

