### PR TITLE
Add area tag to default valid_tags in IFilterSchema

### DIFF
--- a/news/+tag-area.bugfix
+++ b/news/+tag-area.bugfix
@@ -1,0 +1,1 @@
+Add ``area`` to default ``valid_tags`` so HTML image maps work out of the box. @wesleybl

--- a/src/plone/base/interfaces/controlpanel.py
+++ b/src/plone/base/interfaces/controlpanel.py
@@ -233,6 +233,7 @@ class IFilterSchema(Interface):
             "abbr",
             "acronym",
             "address",
+            "area",
             "article",
             "aside",
             "audio",

--- a/src/plone/base/tests/test_controlpanel.py
+++ b/src/plone/base/tests/test_controlpanel.py
@@ -1,0 +1,14 @@
+"""Unit tests for controlpanel schema."""
+
+from plone.base.interfaces import IFilterSchema
+from zope.schema import getFields
+
+import unittest
+
+
+class FilterSchemaTests(unittest.TestCase):
+    def test_area_tag_in_valid_tags_default(self):
+        """Verify that 'area' is in the default valid_tags list."""
+        fields = getFields(IFilterSchema)
+        valid_tags_field = fields["valid_tags"]
+        self.assertIn("area", valid_tags_field.default)


### PR DESCRIPTION
The HTML sanitizer allows `<map>` by default but strips its required child element `<area>`, making image maps unusable. Add `<area>` to the default `valid_tags` list so image maps work out of the box.

Closes https://github.com/plone/Products.CMFPlone/issues/4348